### PR TITLE
Remove an unused function

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -51,18 +51,6 @@ window.secureShared = {
         return input.replace(/-/g, '+').replace(/_/, '/');
     },
 
-    fileSize: function (fileSizeInBytes) {
-        var i = -1;
-        var byteUnits = [' kB', ' MB', ' GB', ' TB', 'PB', 'EB', 'ZB',
-            'YB'
-        ];
-        do {
-            fileSizeInBytes = fileSizeInBytes / 1024;
-            i++;
-        } while (fileSizeInBytes > 1024);
-
-        return Math.max(fileSizeInBytes, 0.1).toFixed(1) + byteUnits[i];
-    },
     uintToString: function(uintArray) {
         var encodedString = String.fromCharCode.apply(null, uintArray),
             decodedString = decodeURIComponent(escape(encodedString));


### PR DESCRIPTION
I don't see this function used anywhere in the code. If this is useful for some reason, I would recommend using a third-party package such as `fileer:size`.
